### PR TITLE
CLOUDP-268006: Add support for drop in cluster mode

### DIFF
--- a/database/clickhouse/clickhouse.go
+++ b/database/clickhouse/clickhouse.go
@@ -279,6 +279,10 @@ func (ch *ClickHouse) Drop() (err error) {
 
 		query = "DROP TABLE IF EXISTS " + quoteIdentifier(ch.config.DatabaseName) + "." + quoteIdentifier(table)
 
+		if len(ch.config.ClusterName) > 0 {
+			query = query + " ON CLUSTER " + ch.config.ClusterName
+		}
+
 		if _, err := ch.conn.Exec(query); err != nil {
 			return &database.Error{OrigErr: err, Query: []byte(query)}
 		}


### PR DESCRIPTION
Missed in first PR but now drop deletes all tables across the entire cluster when in cluster mode